### PR TITLE
Set /Z7 as a default debug info format for release and debug

### DIFF
--- a/builds/msvc/properties/Debug.props
+++ b/builds/msvc/properties/Debug.props
@@ -13,7 +13,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/builds/msvc/properties/DebugLIB.props
+++ b/builds/msvc/properties/DebugLIB.props
@@ -12,7 +12,6 @@
   
   <ItemDefinitionGroup>
     <ClCompile>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <LinkIncremental>true</LinkIncremental>
     </ClCompile>

--- a/builds/msvc/properties/DebugLTCG.props
+++ b/builds/msvc/properties/DebugLTCG.props
@@ -12,7 +12,6 @@
 
   <ItemDefinitionGroup>
     <ClCompile>
-      <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>

--- a/builds/msvc/properties/Release.props
+++ b/builds/msvc/properties/Release.props
@@ -14,7 +14,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalOptions>/Oy- %(AdditionalOptions)</AdditionalOptions>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>


### PR DESCRIPTION
This is making that change of the v143 toolchain, which I hope will be one used to build our nuget package.